### PR TITLE
Fix admin dashboard entity counts

### DIFF
--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -19,16 +19,16 @@ useEffect(() => {
       const token = localStorage.getItem("token");
 
       const [patientsRes, doctorsRes, adminsRes, prescriptionsRes] = await Promise.all([
-        axios.get("http://localhost:8080/api/patients/patient-count", {
+        axios.get("http://localhost:8080/api/patients/count", {
           headers: { Authorization: `Bearer ${token}` },
         }),
-        axios.get("http://localhost:8080/admin/doctor-count", {
+        axios.get("http://localhost:8080/api/doctors/count", {
           headers: { Authorization: `Bearer ${token}` },
         }),
-        axios.get("http://localhost:8080/admin/count", {
+        axios.get("http://localhost:8080/api/admins/count", {
           headers: { Authorization: `Bearer ${token}` },
         }),
-        axios.get("http://localhost:8080/prescription/count", {
+        axios.get("http://localhost:8080/api/prescriptions/count", {
           headers: { Authorization: `Bearer ${token}` },
         }),
       ]);


### PR DESCRIPTION
Standardize API endpoints in `AdminDashboard.js` to resolve 403 Forbidden errors for count fetches.

---
<a href="https://cursor.com/background-agent?bcId=bc-de52b2d6-5fa7-4d69-9b9c-0e5134f2d78c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de52b2d6-5fa7-4d69-9b9c-0e5134f2d78c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>