### PR TITLE
Fix admin dashboard immediate signout redirect

### DIFF
--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -18,7 +18,7 @@ const [showUserDropdown, setShowUserDropdown] = useState(false);
 useEffect(() => {
   const fetchStats = async () => {
     try {
-      const token = localStorage.getItem("token");
+      const token = localStorage.getItem("authToken");
 
       const [patientsRes, doctorsRes, adminsRes, prescriptionsRes] = await Promise.all([
         axios.get("http://localhost:8080/api/patients/patient-count", {
@@ -48,10 +48,10 @@ useEffect(() => {
 }, []);
 
 const handleSignout = () => {
-  localStorage.removeItem("token");
-  localStorage.removeItem("user");
+  localStorage.removeItem("authToken");
+  localStorage.removeItem("userSession");
   setAuth({ isAuthenticated: false, user: null });
-  window.location.href = "/login";
+  window.location.href = "/";
 };
 
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix sign-out functionality in AdminDashboard by correcting localStorage keys and redirect path.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous sign-out used incorrect localStorage keys (`token`, `user`) while the application's authentication check and login component used `authToken` and `userSession`. This caused the authentication data to persist, leading to immediate redirection back to the dashboard. The redirect path was also updated from `/login` to `/`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcc3fc20-3cbc-476c-967f-d94de6df2067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcc3fc20-3cbc-476c-967f-d94de6df2067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>