### PR TITLE
Investigate duplicate database entries

### DIFF
--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -263,7 +263,8 @@ const handleSignout = () => {
 
     function initFormHandling() {
       const patientForm = document.getElementById("patient-form");
-      if (patientForm) {
+      if (patientForm && !patientForm.hasAttribute("data-listener-attached")) {
+          patientForm.setAttribute("data-listener-attached", "true");
           patientForm.addEventListener("submit", async (e) => {
           e.preventDefault();
           const formData = new FormData(patientForm);
@@ -440,7 +441,8 @@ if (phone && phone.length < 10) {
 
       // Doctor Form
       const doctorForm = document.getElementById("doctor-form");
-      if (doctorForm) {
+      if (doctorForm && !doctorForm.hasAttribute("data-listener-attached")) {
+        doctorForm.setAttribute("data-listener-attached", "true");
         doctorForm.addEventListener("submit", (e) => {
           e.preventDefault();
           const formData = new FormData(doctorForm);
@@ -734,7 +736,11 @@ if (phone && phone.length < 10) {
 
 
     // Initialize everything when DOM is loaded
-      const initializeComponents = () => {
+    let isInitialized = false;
+    const initializeComponents = () => {
+      // Prevent multiple initializations
+      if (isInitialized) return;
+      isInitialized = true;
 
       initTabNavigation();
       initFormHandling();


### PR DESCRIPTION
Prevent duplicate form submissions by ensuring form event listeners are attached only once.

The `initializeComponents` function was being called multiple times (via `setTimeout` and `DOMContentLoaded`), leading to `initFormHandling` attaching duplicate event listeners to the patient and doctor forms. This caused forms to be submitted twice, resulting in duplicate database entries. The fix ensures these initializations and listener attachments occur only once.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c9f61c7-ea88-4ae7-8450-49d40793a0cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c9f61c7-ea88-4ae7-8450-49d40793a0cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>