### PR TITLE
Fix null replace error in AdminList

### DIFF
--- a/src/components/AdminList.js
+++ b/src/components/AdminList.js
@@ -140,6 +140,9 @@ const AdminList = () => {
   };
   // Format admin type
   const getAdminTypeBadge = (adminType) => {
+    if (!adminType) {
+      return <span className="admin-type-badge admin-type-unknown">Unknown</span>;
+    }
     const typeClass = 
       adminType === 'SUPER_ADMIN' ? 'admin-type-super' :
       adminType === 'STAFF_ADMIN' ? 'admin-type-staff' : 'admin-type-support';


### PR DESCRIPTION
Add null check to `getAdminTypeBadge` to prevent `TypeError` when `adminType` is null.

The error `Cannot read properties of null (reading 'replace')` occurred because `adminType.replace` was called on a null value. This change ensures graceful handling by displaying "Unknown" instead of crashing.

---
<a href="https://cursor.com/background-agent?bcId=bc-64696365-1fab-4493-a8af-f771f14b5069">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64696365-1fab-4493-a8af-f771f14b5069">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

