### PR TITLE
Fix fullscreen background color in dark mode

### DIFF
--- a/src/styles/PatientList.css
+++ b/src/styles/PatientList.css
@@ -13,7 +13,7 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: #f5f7fa;
+  background: var(--background-color);
   z-index: 9999;
   padding: 20px;
   overflow: auto;
@@ -37,16 +37,16 @@
 }
 
 .patient-list-container.fullscreen-mode .patient-card {
-  background: #ffffff;
-  border: 1px solid #e1e5e9;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
 }
 
 .patient-list-container.fullscreen-mode .card-header {
-  background: #ffffff;
+  background: var(--surface-color);
 }
 
 .patient-list-container.fullscreen-mode .card-body {
-  background: #ffffff;
+  background: var(--surface-color);
 }
 
 


### PR DESCRIPTION
Fix fullscreen mode background and card colors to respect dark theme by using CSS variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f2ee0dc-6f91-4619-9599-9c65e0c84808">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f2ee0dc-6f91-4619-9599-9c65e0c84808">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

