### PR TITLE
Fix admin dashboard signout button

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,21 @@ function App() {
     user: null, // Complete user profile data
   });
 
+  // Centralized logout function
+  const handleLogout = () => {
+    // Clear localStorage
+    localStorage.removeItem('authToken');
+    localStorage.removeItem('userSession');
+    
+    // Reset auth state
+    setAuth({
+      isAuthenticated: false,
+      role: null,
+      username: "",
+      user: null,
+    });
+  };
+
   // Check for existing authentication on app load
   useEffect(() => {
     const token = localStorage.getItem('authToken');
@@ -87,7 +102,7 @@ function App() {
               userRole={auth.role} 
               isAuthenticated={auth.isAuthenticated}
             >
-              <AdminDashboard auth={auth} setAuth={setAuth} />
+              <AdminDashboard auth={auth} setAuth={setAuth} onLogout={handleLogout} />
             </ProtectedRoute>
           } 
         />
@@ -101,7 +116,7 @@ function App() {
               userRole={auth.role} 
               isAuthenticated={auth.isAuthenticated}
             >
-              <DoctorDashboard auth={auth} setAuth={setAuth} />
+              <DoctorDashboard auth={auth} setAuth={setAuth} onLogout={handleLogout} />
             </ProtectedRoute>
           } 
         />
@@ -115,7 +130,7 @@ function App() {
               userRole={auth.role} 
               isAuthenticated={auth.isAuthenticated}
             >
-              <PatientDashboard auth={auth} setAuth={setAuth} />
+              <PatientDashboard auth={auth} setAuth={setAuth} onLogout={handleLogout} />
             </ProtectedRoute>
           } 
         />


### PR DESCRIPTION
Fix signout functionality across all dashboards by passing the `onLogout` prop.

---
<a href="https://cursor.com/background-agent?bcId=bc-1000031f-4b91-47ac-9717-45277be19fcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1000031f-4b91-47ac-9717-45277be19fcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

