### PR TITLE
Fix broken signout onclick function

### DIFF
--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -63,6 +63,8 @@ useEffect(() => {
       localStorage.removeItem('authToken');
       localStorage.removeItem('userId');
       localStorage.removeItem('userSession');
+      console.log('AdminDashboard: localStorage items removed');
+      
       onLogout();
       console.log('AdminDashboard: onLogout completed');
    
@@ -701,6 +703,10 @@ if (phone && phone.length < 10) {
     }
 
     function handleDocumentClickForDropdown(e) {
+      // Don't close dropdown if clicking on dropdown items
+      if (e.target.closest('.dropdown-item')) {
+        return;
+      }
       if (userProfile && !userProfile.contains(e.target)) {
         setShowUserDropdown(false);
       }
@@ -1013,9 +1019,9 @@ if (phone && phone.length < 10) {
                   e.preventDefault();
                   e.stopPropagation();
                   console.log('Logout button clicked');
+                  setShowUserDropdown(false);
                   handleLogout();
                 }}>
-
                   <i className="fas fa-sign-out-alt"></i>
                   <span>Sign Out</span>
                 </div>


### PR DESCRIPTION
Fixes Admin Dashboard sign-out button not working by preventing premature dropdown closure.

The `handleDocumentClickForDropdown` was closing the dropdown immediately on any click outside the user profile, including clicks on the sign-out button within the dropdown, which prevented the sign-out button's `onClick` handler from executing. The fix ensures clicks on dropdown items are ignored by the document handler and explicitly closes the dropdown after the logout process begins.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d952879-5c94-4a38-9fcd-be2915ecc2a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d952879-5c94-4a38-9fcd-be2915ecc2a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

